### PR TITLE
タスク永続化実装に応じたテストの修正

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -1,1 +1,1 @@
-[{"name":"ノートを買う","state":false},{"name":"鉛筆を買う","state":false}]
+[]

--- a/test.js
+++ b/test.js
@@ -1,21 +1,24 @@
 'use strict';
-const todo = require('./index.js');
-const assert = require('assert');
+const fs = require('fs');
+fs.unlink('./tasks.json', err => {
+    const todo = require('./index.js');
+    const assert = require('assert');
 
-// add と list のテスト
-todo.add('ノートを買う');
-todo.add('鉛筆を買う');
-assert.deepStrictEqual(todo.list(), ['ノートを買う', '鉛筆を買う']);
+    // add と list のテスト
+    todo.add('ノートを買う');
+    todo.add('鉛筆を買う');
+    assert.deepStrictEqual(todo.list(), ['ノートを買う', '鉛筆を買う']);
 
-// done と donelist のテスト
-todo.done('鉛筆を買う');
-assert.deepStrictEqual(todo.list(), ['ノートを買う']);
-assert.deepStrictEqual(todo.donelist(), ['鉛筆を買う']);
+    // done と donelist のテスト
+    todo.done('鉛筆を買う');
+    assert.deepStrictEqual(todo.list(), ['ノートを買う']);
+    assert.deepStrictEqual(todo.donelist(), ['鉛筆を買う']);
 
-// del のテスト
-todo.del('ノートを買う');
-todo.del('鉛筆を買う');
-assert.deepStrictEqual(todo.list(), []);
-assert.deepStrictEqual(todo.donelist(), []);
+    // del のテスト
+    todo.del('ノートを買う');
+    todo.del('鉛筆を買う');
+    assert.deepStrictEqual(todo.list(), []);
+    assert.deepStrictEqual(todo.donelist(), []);
 
-console.log('テストが正常に完了しました');
+    console.log('テストが正常に完了しました');
+});


### PR DESCRIPTION
タスク永続化実装に応じて、テストの際に既存データを読み込むことでテストが失敗する問題に対応しました。

勉強用のプルリクエストのため、マージは不要です。